### PR TITLE
refactor(cmd): hide help command and group completion under utilities

### DIFF
--- a/cmd/action.go
+++ b/cmd/action.go
@@ -12,9 +12,10 @@ var (
 )
 
 var actionCmd = &cobra.Command{
-	Use:   "action",
-	Short: "Manage and list actions",
-	RunE:  runAction,
+	Use:     "action",
+	Short:   "Manage and list actions",
+	RunE:    runAction,
+	GroupID: "worktrees",
 }
 
 func init() {

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -27,13 +27,14 @@ var addCmd = &cobra.Command{
 	Use:   "add [url|name]",
 	Short: "Add a new worktree",
 	Long: `Add a new git worktree from either:
- - A GitHub pull request URL or number
- - A GitHub issue URL or number
- - A name to use for the new worktree and branch
+  - A GitHub pull request URL or number
+  - A GitHub issue URL or number
+  - A name to use for the new worktree and branch
 `,
 	Aliases: []string{"create"},
 	Args:    cobra.RangeArgs(0, 1),
 	RunE:    runAdd,
+	GroupID: "worktrees",
 }
 
 func init() {

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -19,6 +19,7 @@ var rmCmd = &cobra.Command{
 	Aliases: []string{"remove"},
 	Args:    cobra.ExactArgs(1),
 	RunE:    runRm,
+	GroupID: "worktrees",
 }
 
 func init() {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -113,6 +113,10 @@ func Execute() {
 }
 
 func init() {
+	// Define command groups
+	rootCmd.AddGroup(&cobra.Group{ID: "worktrees", Title: "Worktrees"})
+	rootCmd.AddGroup(&cobra.Group{ID: "utilities", Title: "Utilities"})
+
 	// Global flags
 	rootCmd.PersistentFlags().BoolVarP(&forceFlag, "force", "f", false, "force operation without prompts")
 	rootCmd.PersistentFlags().BoolVar(&verbose, "verbose", false, "verbose output")
@@ -123,5 +127,14 @@ func init() {
 	rootCmd.SetVersionTemplate(`gh-wt {{printf "version %s\n" .Version}}`)
 
 	// Add completion command
-	rootCmd.AddCommand(NewCompletionCommand())
+	completionCmd := NewCompletionCommand()
+	completionCmd.GroupID = "utilities"
+	rootCmd.AddCommand(completionCmd)
+
+	// Hide help command
+	rootCmd.SetHelpCommand(&cobra.Command{
+		Use:    "help",
+		Short:  "Help about any command",
+		Hidden: true,
+	})
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -34,8 +34,9 @@ Examples:
 
   # Show help
   gh wt run pr_123`,
-	Args: cobra.RangeArgs(1, 2),
-	RunE: runRun,
+	Args:    cobra.RangeArgs(1, 2),
+	RunE:    runRun,
+	GroupID: "worktrees",
 }
 
 func init() {


### PR DESCRIPTION
## Summary
- Hide the help command from CLI output
- Group completion command under a "utilities" category
- Group worktree-related commands (add, rm, run, action) under a "worktrees" category