### PR TITLE
docs: use heredoc for multi-line strings and separate examples

### DIFF
--- a/cmd/action.go
+++ b/cmd/action.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"github.com/MakeNowJust/heredoc"
 	"github.com/ffalor/gh-wt/internal/config"
 	"github.com/ffalor/gh-wt/internal/logger"
 	"github.com/spf13/cobra"
@@ -12,8 +13,18 @@ var (
 )
 
 var actionCmd = &cobra.Command{
-	Use:     "action",
-	Short:   "Manage and list actions",
+	Use:   "action",
+	Short: "Manage and list actions",
+	Long: heredoc.Doc(`
+		Manage and list actions configured in the gh-wt config file.
+	`),
+	Example: heredoc.Doc(`
+		# List all available actions
+		gh wt action --list
+
+		# List action names only (silent mode)
+		gh wt action -s
+	`),
 	RunE:    runAction,
 	GroupID: "worktrees",
 }

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -10,6 +10,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/MakeNowJust/heredoc"
 	gh "github.com/cli/go-gh/v2"
 	"github.com/cli/go-gh/v2/pkg/prompter"
 	"github.com/cli/go-gh/v2/pkg/repository"
@@ -26,11 +27,22 @@ import (
 var addCmd = &cobra.Command{
 	Use:   "add [url|name]",
 	Short: "Add a new worktree",
-	Long: `Add a new git worktree from either:
-  - A GitHub pull request URL or number
-  - A GitHub issue URL or number
-  - A name to use for the new worktree and branch
-`,
+	Long: heredoc.Doc(`
+		Add a new git worktree from either:
+		  - A GitHub pull request URL or number
+		  - A GitHub issue URL or number
+		  - A name to use for the new worktree and branch
+	`),
+	Example: heredoc.Doc(`
+		# Create worktree from PR URL
+		gh wt add https://github.com/owner/repo/pull/123
+
+		# Create worktree from Issue URL
+		gh wt add https://github.com/owner/repo/issues/456
+
+		# Create a worktree from a local branch
+		gh wt add my-feature-branch
+	`),
 	Aliases: []string{"create"},
 	Args:    cobra.RangeArgs(0, 1),
 	RunE:    runAdd,

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"os"
 
+	"github.com/MakeNowJust/heredoc"
 	"github.com/ffalor/gh-wt/internal/completion"
 	"github.com/spf13/cobra"
 )
@@ -12,33 +13,35 @@ func NewCompletionCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "completion [shell]",
 		Short: "Generate shell completion scripts for gh wt commands",
-		Long: `Generate shell completion scripts to enable tab completion for gh wt commands.
+		Long: heredoc.Doc(`
+			Generate shell completion scripts to enable tab completion for gh wt commands.
 
-Tab completion provides:
-- Command name completion (add, remove, run, action)
-- Subcommand completion (install, uninstall)
-- Flag completion
+			Tab completion provides:
+			- Command name completion (add, remove, run, action)
+			- Subcommand completion (install, uninstall)
+			- Flag completion
 
-Supported shells: bash, zsh, fish, powershell
+			Supported shells: bash, zsh, fish, powershell
+		`),
+		Example: heredoc.Doc(`
+			# Generate completion script for bash
+			gh wt completion bash
 
-Examples:
-  # Generate completion script for bash
-  gh wt completion bash
+			# Generate completion script for zsh
+			gh wt completion zsh
 
-  # Generate completion script for zsh
-  gh wt completion zsh
+			# Generate completion script for fish
+			gh wt completion fish
 
-  # Generate completion script for fish
-  gh wt completion fish
+			# Generate completion script for PowerShell
+			gh wt completion powershell
 
-  # Generate completion script for PowerShell
-  gh wt completion powershell
+			# Install completions automatically (detects your shell)
+			gh wt completion install
 
-  # Install completions automatically (detects your shell)
-  gh wt completion install
-
-  # Uninstall completions
-  gh wt completion uninstall`,
+			# Uninstall completions
+			gh wt completion uninstall
+		`),
 		ValidArgs: []string{"bash", "zsh", "fish", "powershell"},
 		Args:      cobra.ExactValidArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -63,21 +66,23 @@ Examples:
 	installCmd := &cobra.Command{
 		Use:   "install",
 		Short: "Install shell completion for the detected shell",
-		Long: `Automatically install shell completion for your current shell.
+		Long: heredoc.Doc(`
+			Automatically install shell completion for your current shell.
 
-This command detects your shell (bash, zsh, fish, or PowerShell) and installs
-the completion script to the appropriate location. After installation, restart
-your shell or source your shell configuration file.
+			This command detects your shell (bash, zsh, fish, or PowerShell) and installs
+			the completion script to the appropriate location. After installation, restart
+			your shell or source your shell configuration file.
 
-Supported shells:
-  - Bash: Installs to ~/.bash_completion.d/ or /etc/bash_completion.d/
-  - Zsh: Installs to ~/.zsh/completions/
-  - Fish: Installs to ~/.config/fish/completions/
-  - PowerShell: Provides instructions to add to profile
-
-Examples:
-  gh wt completion install
-	gh wt completion install --verbose`,
+			Supported shells:
+			  - Bash: Installs to ~/.bash_completion.d/ or /etc/bash_completion.d/
+			  - Zsh: Installs to ~/.zsh/completions/
+			  - Fish: Installs to ~/.config/fish/completions/
+			  - PowerShell: Provides instructions to add to profile
+		`),
+		Example: heredoc.Doc(`
+			gh wt completion install
+			gh wt completion install --verbose
+		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return completion.InstallShellCompletion(Log, cmd.Root())
 		},
@@ -87,15 +92,17 @@ Examples:
 	uninstallCmd := &cobra.Command{
 		Use:   "uninstall",
 		Short: "Uninstall shell completion for the detected shell",
-		Long: `Automatically uninstall shell completion for your current shell.
+		Long: heredoc.Doc(`
+			Automatically uninstall shell completion for your current shell.
 
-This command detects your shell and removes the completion script from the
-appropriate location. After uninstallation, restart your shell or source
-your shell configuration file.
-
-Examples:
-  gh wt completion uninstall
-  gh wt completion uninstall --verbose`,
+			This command detects your shell and removes the completion script from the
+			appropriate location. After uninstallation, restart your shell or source
+			your shell configuration file.
+		`),
+		Example: heredoc.Doc(`
+			gh wt completion uninstall
+			gh wt completion uninstall --verbose
+		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return completion.UninstallShellCompletion(Log)
 		},

--- a/cmd/completion_test.go
+++ b/cmd/completion_test.go
@@ -121,10 +121,10 @@ func TestCompletionCommand_Examples(t *testing.T) {
 	cmd := NewCompletionCommand()
 
 	// Verify examples are present for all shells
-	assert.Contains(t, cmd.Long, "gh wt completion bash")
-	assert.Contains(t, cmd.Long, "gh wt completion zsh")
-	assert.Contains(t, cmd.Long, "gh wt completion fish")
-	assert.Contains(t, cmd.Long, "gh wt completion powershell")
+	assert.Contains(t, cmd.Example, "gh wt completion bash")
+	assert.Contains(t, cmd.Example, "gh wt completion zsh")
+	assert.Contains(t, cmd.Example, "gh wt completion fish")
+	assert.Contains(t, cmd.Example, "gh wt completion powershell")
 }
 
 func TestCompletionCommand_ValidArgs(t *testing.T) {

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/go-gh/v2/pkg/prompter"
 	"github.com/ffalor/gh-wt/internal/git"
 	"github.com/ffalor/gh-wt/internal/logger"
@@ -13,9 +14,19 @@ import (
 
 // rmCmd represents the rm command.
 var rmCmd = &cobra.Command{
-	Use:     "rm [worktree-name]",
-	Short:   "Remove a worktree and its associated branch",
-	Long:    `Remove a worktree and its associated branch. Will prompt if there are uncommitted changes (unless --force is used).`,
+	Use:   "rm [worktree-name]",
+	Short: "Remove a worktree and its associated branch",
+	Long: heredoc.Doc(`
+		Remove a worktree and its associated branch. Will prompt if there are
+		uncommitted changes (unless --force is used).
+	`),
+	Example: heredoc.Doc(`
+		# Remove a worktree by name
+		gh wt rm pr_123
+
+		# Remove a worktree with force
+		gh wt rm issue_456 --force
+	`),
 	Aliases: []string{"remove"},
 	Args:    cobra.ExactArgs(1),
 	RunE:    runRm,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,6 +7,7 @@ import (
 	"runtime/debug"
 	"strings"
 
+	"github.com/MakeNowJust/heredoc"
 	"github.com/ffalor/gh-wt/internal/config"
 	"github.com/ffalor/gh-wt/internal/logger"
 	"github.com/spf13/cobra"
@@ -61,20 +62,23 @@ var rootCmd = &cobra.Command{
 		cobra.CommandDisplayNameAnnotation: "gh wt",
 	},
 	Short: "Create and manage git worktrees",
-	Long: `gh wt is a GitHub CLI extension that helps you create git worktrees. A GitHub pull request or issue url can also be used.
+	Long: heredoc.Doc(`
+		gh wt is a GitHub CLI extension that helps you create git worktrees.
+		A GitHub pull request or issue URL can also be used.
+	`),
+	Example: heredoc.Doc(`
+		# Create worktree from PR URL
+		gh wt add https://github.com/owner/repo/pull/123 -a claude -- "/review"
 
-Examples:
-  # Create worktree from PR URL
-  gh wt add https://github.com/owner/repo/pull/123 -a claude -- "/review"
+		# Create worktree from Issue URL
+		gh wt add https://github.com/owner/repo/issues/456 -a claude -- "implement issue #456"
 
-  # Create worktree from Issue URL
-  gh wt add https://github.com/owner/repo/issues/456 -a claude -- "implement issue #456"
+		# Create a worktree
+		gh wt add my-feature-branch
 
-  # Create a worktree
-  gh wt add my-feature-branch
-
-  # Remove a worktree
-  gh wt rm pr_123`,
+		# Remove a worktree
+		gh wt rm pr_123
+	`),
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		_, err := config.Load()
 		if err != nil {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/go-gh/v2/pkg/prompter"
 	"github.com/cli/go-gh/v2/pkg/repository"
 	"github.com/ffalor/gh-wt/internal/action"
@@ -19,21 +20,23 @@ import (
 var runCmd = &cobra.Command{
 	Use:   "run <worktree> [action] [-- command]",
 	Short: "Run an action or command in an existing worktree",
-	Long: `Run an action or command in an existing worktree.
+	Long: heredoc.Doc(`
+		Run an action or command in an existing worktree.
 
-Use this command to:
-- Run configured actions on worktrees that were created without an action
-- Run commands directly in a worktree
+		Use this command to:
+		- Run configured actions on worktrees that were created without an action
+		- Run commands directly in a worktree
+	`),
+	Example: heredoc.Doc(`
+		# Run named action on worktree
+		gh wt run pr_123 claude -- fix issue #456
 
-Examples:
-  # Run named action on worktree
-  gh wt run pr_123 claude -- fix issue #456
+		# Run command directly in worktree
+		gh wt run pr_123 -- ls
 
-  # Run command directly in worktree
-  gh wt run pr_123 -- ls
-
-  # Show help
-  gh wt run pr_123`,
+		# Show help
+		gh wt run pr_123
+	`),
 	Args:    cobra.RangeArgs(1, 2),
 	RunE:    runRun,
 	GroupID: "worktrees",

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/ffalor/gh-wt
 go 1.25.0
 
 require (
+	github.com/MakeNowJust/heredoc v1.0.0
 	github.com/cli/go-gh/v2 v2.13.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0


### PR DESCRIPTION
## Summary

- Use `github.com/MakeNowJust/heredoc` package for `Long:` and `Example:` fields in command definitions
- Move examples from embedded `Long:` field to dedicated `Example:` field
- Update tests to reflect the new structure

This follows the pattern used by the GitHub CLI (`github.com/cli/cli`) for better formatting and maintainability.

## Changes

- `cmd/add.go` - Add heredoc for Long and Example fields
- `cmd/remove.go` - Add heredoc for Long and Example fields
- `cmd/root.go` - Move examples to Example field
- `cmd/run.go` - Move examples to Example field
- `cmd/completion.go` - Move examples to Example field
- `cmd/action.go` - Add Long and Example fields
- `cmd/completion_test.go` - Fix test to check Example field