### PR TITLE
fix(add): respect --branch flag when --name flag is also provided

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -213,22 +213,26 @@ func createFromLocal(name string) error {
 		return err
 	}
 
-	// Sanitize the name for the branch
-	sanitizedBranchName := SanitizeBranchName(name)
+	// Branch name: --branch > --name > argument
+	branchName := name
 	if branchFlag != "" {
-		sanitizedBranchName = SanitizeBranchName(branchFlag)
+		branchName = branchFlag
+	} else if nameFlag != "" {
+		branchName = nameFlag
 	}
 
+	// Worktree name: --name > argument
 	worktreeName := name
 	if nameFlag != "" {
 		worktreeName = nameFlag
-		sanitizedBranchName = SanitizeBranchName(nameFlag)
 	}
+
+	branchName = SanitizeBranchName(branchName)
 
 	info := &worktree.WorktreeInfo{
 		Type:         worktree.Local,
 		Repo:         repoName,
-		BranchName:   sanitizedBranchName,
+		BranchName:   branchName,
 		WorktreeName: worktreeName,
 	}
 


### PR DESCRIPTION
When both -b (branch) and -n (name) flags are provided to gh wt add, the branch name was incorrectly being set to the name value instead of using the branch flag value.

This fixes the priority to correctly use:
- Branch name: --branch > --name > argument
- Worktree name: --name > argument