### PR TITLE
feat(action): add WorktreeName template variable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -197,6 +197,7 @@ actions:
 Action template variables:
 
 - `{{.WorktreePath}}` - Path to worktree
+- `{{.WorktreeName}}` - Name of the worktree directory
 - `{{.BranchName}}` - Branch name
 - `{{.Action}}` - Action name
 - `{{.CLI_ARGS}}` - CLI arguments after --

--- a/internal/action/action.go
+++ b/internal/action/action.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"text/template"
@@ -105,6 +106,7 @@ func Execute(ctx context.Context, opts *ExecuteOptions) error {
 	// Prepare data for template
 	data := struct {
 		WorktreePath string
+		WorktreeName string
 		Action       string
 		CLI_ARGS     string
 		OS           string
@@ -113,6 +115,7 @@ func Execute(ctx context.Context, opts *ExecuteOptions) error {
 		*worktree.WorktreeInfo
 	}{
 		WorktreePath: opts.WorktreePath,
+		WorktreeName: filepath.Base(opts.WorktreePath),
 		Action:       opts.ActionName,
 		CLI_ARGS:     opts.CLIArgs,
 		OS:           runtime.GOOS,

--- a/website/src/pages/docs/actions.md
+++ b/website/src/pages/docs/actions.md
@@ -47,6 +47,11 @@ title: Actions
       <td><code>~/github/worktree/pr_123</code></td>
     </tr>
     <tr>
+      <td><code>{{.WorktreeName}}</code></td>
+      <td>Name of the worktree directory</td>
+      <td><code>pr_123</code></td>
+    </tr>
+    <tr>
       <td><code>{{.BranchName}}</code></td>
       <td>Name of the branch</td>
       <td><code>pr_123</code></td>


### PR DESCRIPTION
## Summary

- Adds `{{.WorktreeName}}` template variable for actions, providing the worktree directory name (e.g., `pr_123` from `~/github/worktree/pr_123`)
- Implements `filepath.Base()` to extract the directory name from the full worktree path
- Updates documentation in AGENTS.md and website docs

Closes #40