### PR TITLE
fix(docgen): correct root command synopsis usage

### DIFF
--- a/internal/tools/docgen/main.go
+++ b/internal/tools/docgen/main.go
@@ -104,7 +104,11 @@ func genMarkdown(buf *bytes.Buffer, cmd *cobra.Command) error {
 	if cmd.Long != "" {
 		buf.WriteString(cmd.Long + "\n\n")
 	}
-	fmt.Fprintf(buf, "```\n%s\n```\n\n", cmd.UseLine())
+	synopsis := cmd.CommandPath()
+	if cmd.Parent() != nil {
+		synopsis = cmd.UseLine()
+	}
+	fmt.Fprintf(buf, "```\n%s\n```\n\n", synopsis)
 
 	// Examples
 	if cmd.Example != "" {

--- a/website/src/layouts/DocsLayout.astro
+++ b/website/src/layouts/DocsLayout.astro
@@ -89,13 +89,14 @@ const { title, description = 'GitHub CLI extension for managing git worktrees' }
         copyButton.className = 'copy-button';
         copyButton.setAttribute('aria-label', 'Copy code');
         copyButton.innerHTML = `
-          <svg class="copy-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <svg class="copy-icon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
             <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
             <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
           </svg>
-          <svg class="check-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="display: none;">
+          <svg class="check-icon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="display: none;">
             <polyline points="20 6 9 17 4 12"></polyline>
           </svg>
+          <span class="copy-text">Copy</span>
         `;
 
         copyButton.addEventListener('click', async () => {
@@ -104,15 +105,18 @@ const { title, description = 'GitHub CLI extension for managing git worktrees' }
             
             const copyIcon = copyButton.querySelector('.copy-icon') as SVGElement;
             const checkIcon = copyButton.querySelector('.check-icon') as SVGElement;
+            const copyText = copyButton.querySelector('.copy-text') as HTMLElement;
 
             if (copyIcon) copyIcon.style.display = 'none';
             if (checkIcon) checkIcon.style.display = 'block';
+            if (copyText) copyText.textContent = 'Copied!';
             
             copyButton.classList.add('copied');
             
             setTimeout(() => {
               if (copyIcon) copyIcon.style.display = 'block';
               if (checkIcon) checkIcon.style.display = 'none';
+              if (copyText) copyText.textContent = 'Copy';
               copyButton.classList.remove('copied');
             }, 2000);
           } catch (err) {

--- a/website/src/pages/docs/cli/gh_wt.mdx
+++ b/website/src/pages/docs/cli/gh_wt.mdx
@@ -16,7 +16,7 @@ A GitHub pull request or issue URL can also be used.
 
 
 ```
-gh wt wt
+gh wt
 ```
 
 ### Examples

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -150,19 +150,39 @@ code {
 
 pre {
   font-family: var(--font-mono);
-  background: 
-    linear-gradient(90deg, var(--color-cyan), var(--color-magenta)) top / 100% 3px no-repeat,
-    var(--bg-secondary);
-  background-clip: border-box, padding-box;
+  background: var(--bg-secondary) !important;
   border: 1px solid var(--border-color);
   border-radius: 8px;
   padding: 1.5rem;
-  overflow-x: auto;
+  overflow-x: auto !important;
+  white-space: pre !important;
   position: relative;
 }
 
 pre::before {
-  display: none;
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  background: linear-gradient(90deg, var(--color-cyan), var(--color-magenta));
+  border-radius: 8px 8px 0 0;
+}
+
+@media (max-width: 768px) {
+  pre {
+    background: 
+      linear-gradient(90deg, var(--color-cyan), var(--color-magenta)) top / 100% 3px no-repeat,
+      var(--bg-secondary) !important;
+    background-clip: border-box, padding-box;
+    overflow-x: auto !important;
+    white-space: pre !important;
+  }
+
+  pre::before {
+    display: none;
+  }
 }
 
 pre code {
@@ -383,21 +403,23 @@ pre code {
 
 .copy-button {
   position: absolute;
-  top: 0.5rem;
-  right: 0.5rem;
+  top: 0.75rem;
+  right: 0.75rem;
   display: flex;
   align-items: center;
-  justify-content: center;
-  padding: 0.4rem;
-  background: linear-gradient(180deg, var(--bg-tertiary) 0%, var(--bg-secondary) 100%);
-  border: none;
+  gap: 0.4rem;
+  padding: 0.4rem 0.75rem;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-color);
   border-radius: 6px;
   color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
   cursor: pointer;
   transition: all var(--transition-fast);
   z-index: 10;
   opacity: 0;
-  }
+}
 
 .code-block-wrapper:hover .copy-button {
   opacity: 1;
@@ -405,11 +427,13 @@ pre code {
 
 .copy-button:hover {
   background: var(--bg-elevated);
+  border-color: var(--color-cyan);
   color: var(--color-cyan);
   box-shadow: 0 0 10px rgba(0, 255, 249, 0.2);
 }
 
 .copy-button.copied {
+  border-color: var(--color-green);
   color: var(--color-green);
   box-shadow: 0 0 10px rgba(0, 255, 136, 0.2);
   opacity: 1;
@@ -421,7 +445,9 @@ pre code {
 }
 
 .copy-text {
-  display: none;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-weight: 500;
 }
 
 @keyframes copyPulse {
@@ -436,6 +462,14 @@ pre code {
 @media (hover: none), (pointer: coarse) {
   .copy-button {
     opacity: 1;
+    padding: 0.4rem;
+    justify-content: center;
+    border: none;
+    background: linear-gradient(180deg, var(--bg-tertiary) 0%, var(--bg-secondary) 100%);
+  }
+
+  .copy-text {
+    display: none;
   }
 
   .copy-button:hover,
@@ -444,11 +478,13 @@ pre code {
     background: var(--bg-tertiary);
     color: var(--text-secondary);
     box-shadow: none;
+    border: 1px solid var(--border-color);
   }
 
   .copy-button.copied {
     color: var(--color-green);
     box-shadow: 0 0 10px rgba(0, 255, 136, 0.2);
     opacity: 1;
+    border: none;
   }
 }


### PR DESCRIPTION
## Summary

- Fix root command synopsis showing "gh wt wt" instead of "gh wt"
- Use CommandPath() for root command and UseLine() for subcommands to preserve argument placeholders
- Regenerate CLI documentation

Also includes improvements to copy button styling (added "Copy" text, larger icons) and code block styling.